### PR TITLE
Closes #3: Update wp rocket get it now link and learn more link to use main plugin as referrer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+.github export-ignore
+tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+patchwork.json export-ignore
+phpcs.xml export-ignore
+phpstan.neon.dist export-ignore
+README.md export-ignore
+

--- a/src/Model/PluginFamily.php
+++ b/src/Model/PluginFamily.php
@@ -13,9 +13,9 @@ class PluginFamily {
 	 * @var array
 	 */
 	protected $wp_rocket_referrer = [
-		'imagify-plugin' => 'imagify',
-		'seo-by-rank-math' => '',
-		'backwpup' => '',
+		'imagify-plugin'    => 'imagify',
+		'seo-by-rank-math'  => '',
+		'backwpup'          => '',
 		'uk-cookie-consent' => '',
 	];
 
@@ -53,7 +53,7 @@ class PluginFamily {
 				$plugin_path      = $plugin . '.php';
 				$plugin_slug      = dirname( $plugin );
 				$main_plugin_slug = dirname( $main_plugin );
-				$wpr_referrer = 'wp-rocket' !== $main_plugin_slug ? $this->wp_rocket_referrer[ $main_plugin_slug ] : '';
+				$wpr_referrer     = 'wp-rocket' !== $main_plugin_slug ? $this->wp_rocket_referrer[ $main_plugin_slug ] : '';
 
 				/**
 				 * Check for activated plugins and pop them out of the array

--- a/src/Model/PluginFamily.php
+++ b/src/Model/PluginFamily.php
@@ -6,6 +6,19 @@ namespace WPMedia\PluginFamily\Model;
  * Handles the data to be passed to the frontend.
  */
 class PluginFamily {
+
+	/**
+	 * An array of referrers for wp rocket.
+	 *
+	 * @var array
+	 */
+	protected $wp_rocket_referrer = [
+		'imagify-plugin' => 'imagify',
+		'seo-by-rank-math' => '',
+		'backwpup' => '',
+		'uk-cookie-consent' => '',
+	];
+
 	/**
 	 * Get filtered plugins.
 	 *
@@ -40,6 +53,7 @@ class PluginFamily {
 				$plugin_path      = $plugin . '.php';
 				$plugin_slug      = dirname( $plugin );
 				$main_plugin_slug = dirname( $main_plugin );
+				$wpr_referrer = 'wp-rocket' !== $main_plugin_slug ? $this->wp_rocket_referrer[ $main_plugin_slug ] : '';
 
 				/**
 				 * Check for activated plugins and pop them out of the array
@@ -96,10 +110,14 @@ class PluginFamily {
 
 				// Create unique CTA data for WP Rocket.
 				if ( 'wp-rocket/wp-rocket' === $plugin ) {
+					$url = 'https://wp-rocket.me/?utm_source=' . $wpr_referrer . '-coupon&utm_medium=plugin&utm_campaign=' . $wpr_referrer;
+
 					$plugins[ $cat ]['plugins'][ $plugin ]['cta'] = [
 						'text' => 'Get it Now',
-						'url'  => 'https://wp-rocket.me/?utm_source=imagify-coupon&utm_medium=plugin&utm_campaign=imagify',
+						'url'  => $url,
 					];
+
+					$plugins[ $cat ]['plugins'][ $plugin ]['link'] = $url;
 				}
 
 				// Set activation text.

--- a/src/Model/wp_media_plugins.php
+++ b/src/Model/wp_media_plugins.php
@@ -14,7 +14,7 @@ return [
 				],
 				'title' => 'Speed Up Your Website, Instantly',
 				'desc'  => 'WP Rocket is the easiest way to make your WordPress website faster and boost your Google PageSpeed score. Get more traffic, better engagement, and higher conversions effortlessly.',
-				'link'  => 'https://wp-rocket.me/?utm_source=imagify-coupon&utm_medium=plugin&utm_campaign=imagify',
+				'link'  => '',
 			],
 			'imagify-plugin/imagify' => [
 				'logo'  => [

--- a/tests/Fixtures/src/Model/PluginFamily/filterPluginsByActivation.php
+++ b/tests/Fixtures/src/Model/PluginFamily/filterPluginsByActivation.php
@@ -196,7 +196,7 @@ $expectedActivateTextIfPluginIsAlreadyInstalled = [
         ],
         'title' => 'Speed Up Your Website, Instantly',
         'desc'  => 'WP Rocket is the easiest way to make your WordPress website faster and boost your Google PageSpeed score. Get more traffic, better engagement, and higher conversions effortlessly.',
-        'link'  => 'https://wp-rocket.me/?utm_source=imagify-coupon&utm_medium=plugin&utm_campaign=imagify',
+        'link'  => 'https://wp-rocket.me/?utm_source=-coupon&utm_medium=plugin&utm_campaign=',
         'cta'   => [
             'text' => 'Activate',
             'url'  => 'http://example.org/wp-admin/admin-post.php?action=plugin_family_install_wp-rocket&_wpnonce=9a68f00b8d&plugin_to_install=wp-rocket%2Fwp-rocket'
@@ -251,10 +251,10 @@ $expectedUniqueInstallLinkForImagify = [
         ],
         'title' => 'Speed Up Your Website, Instantly',
         'desc'  => 'WP Rocket is the easiest way to make your WordPress website faster and boost your Google PageSpeed score. Get more traffic, better engagement, and higher conversions effortlessly.',
-        'link'  => 'https://wp-rocket.me/?utm_source=imagify-coupon&utm_medium=plugin&utm_campaign=imagify',
+        'link'  => 'https://wp-rocket.me/?utm_source=-coupon&utm_medium=plugin&utm_campaign=',
         'cta'   => [
             'text' => 'Get it Now',
-            'url'  => 'https://wp-rocket.me/?utm_source=imagify-coupon&utm_medium=plugin&utm_campaign=imagify'
+            'url'  => 'https://wp-rocket.me/?utm_source=-coupon&utm_medium=plugin&utm_campaign='
         ],
     ],
     'imagify-plugin/imagify' => [


### PR DESCRIPTION
# Description
Changes static url for GET IT NOW and learn more on WP Rocket to dynamic based on the main installed plugin.

Fixes #3 

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

We don't have a way to test this at the moment, but it could be seen from the code that the url for installation and learn more is static for WP Rocket which favors only Imagify plugin.

## Technical description

### Documentation

Made urls more dynamic based on the main plugin that is installed/calling the plugin families.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style
- [x] I wrote a self-explanatory code about what it does.
- [x] I did not introduce unnecessary complexity.