### PR TITLE
Closes #17: Install link of RankMath must change based on the plugin of origin

### DIFF
--- a/src/Controller/PluginFamily.php
+++ b/src/Controller/PluginFamily.php
@@ -165,6 +165,15 @@ class PluginFamily implements PluginFamilyInterface {
 	 * @return string
 	 */
 	private function get_download_url(): string {
+
+		$slug = $this->get_slug();
+
+		$custom_download_url = $this->maybe_get_custom_download_url( $slug );
+
+		if ( false !== $custom_download_url ) {
+			return $custom_download_url;
+		}
+
 		$plugin_install = ABSPATH . 'wp-admin/includes/plugin-install.php';
 
 		if ( ! defined( 'ABSPATH' ) || ! file_exists( $plugin_install ) ) {
@@ -178,7 +187,7 @@ class PluginFamily implements PluginFamilyInterface {
 		require_once $plugin_install; // @phpstan-ignore-line
 
 		$data = [
-			'slug'   => $this->get_slug(),
+			'slug'   => $slug,
 			'fields' => [
 				'download_link'     => true,
 				'short_description' => false,
@@ -250,5 +259,37 @@ class PluginFamily implements PluginFamilyInterface {
 
 		wp_safe_redirect( wp_get_referer() );
 		exit;
+	}
+
+	/**
+	 * Returns a custom download url for plugin if exists.
+	 *
+	 * @param string $plugin_slug plugin slug.
+	 * @return string|bool
+	 */
+	private function maybe_get_custom_download_url( string $plugin_slug ) {
+		$parent_plugin_slug = $this->get_parent_plugin_slug();
+
+		$urls = [
+			'seo-by-rank-math' => 'https://rankmath.com/downloads/plugin-family/' . $parent_plugin_slug,
+		];
+
+		if ( ! isset( $urls[ $plugin_slug ] ) ) {
+			return false;
+		}
+
+		return $urls[ $plugin_slug ];
+	}
+
+	/**
+	 * Get parent plugin slug.
+	 *
+	 * @return string
+	 */
+	private function get_parent_plugin_slug(): string {
+		$plugin_path = plugin_basename( __FILE__ );
+		$chunks      = explode( '/', $plugin_path );
+
+		return $chunks[0];
 	}
 }


### PR DESCRIPTION
# Description

Fixes #17 
Updates the plugin download url for rankmath to be custom.

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

N/A

## Technical description

### Documentation

Returns custom plugin download url for rankmath.

### New dependencies

N/A

### Risks

N/A

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

No endpoint to protect, no message to output.

# Additional Checks
- [ ] In the case of complex code, I wrote comments to explain it.
- [ ] When possible, I prepared ways to observe the implemented system (logs, data, etc.).
- [ ] I added error handling logic when using functions that could throw errors (HTTP/API request, filesystem, etc.)
