### PR TITLE
FIXES wp-rocket#7556: Adds a filter to show or not the imagify banner

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
 	},
     "require": {
         "wp-media/apply-filters-typed": "^1.0"
-
     },
     "require-dev": {
         "phpcompatibility/phpcompatibility-wp": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,10 @@
             "phpstan/extension-installer": true
         }
 	},
+    "require": {
+        "wp-media/apply-filters-typed": "^1.0"
+
+    },
     "require-dev": {
         "phpcompatibility/phpcompatibility-wp": "^2.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",

--- a/src/Controller/PluginFamily.php
+++ b/src/Controller/PluginFamily.php
@@ -12,7 +12,7 @@ class PluginFamily implements PluginFamilyInterface {
 	 *
 	 * @var string
 	 */
-	private $version = '1.0.7';
+	private $version = '1.0.8';
 
 	/**
 	 * Error transient.

--- a/src/Controller/PluginFamily.php
+++ b/src/Controller/PluginFamily.php
@@ -479,7 +479,7 @@ class PluginFamily implements PluginFamilyInterface {
 		 *
 		 * @param bool $can_enqueue Whether to enqueue the admin assets and show the banner.
 		 */
-		return wpm_apply_filters_typed( 'bool', 'wpmedia_plugin_family_show_imagify_banner', $can_enqueue );
+		return wpm_apply_filters_typed( 'boolean', 'wpmedia_plugin_family_show_imagify_banner', $can_enqueue );
 	}
 
 	/**

--- a/src/Controller/PluginFamily.php
+++ b/src/Controller/PluginFamily.php
@@ -380,14 +380,7 @@ class PluginFamily implements PluginFamilyInterface {
 			return;
 		}
 
-		/**
-		 * Filters whether to show the Imagify banner on Media gallery components.
-		 *
-		 * @since 1.0.8
-		 *
-		 * @param bool $show_banner Whether to enqueue the block editor assets and show the banner.
-		 */
-		if ( ! wpm_apply_filters_typed( 'boolean', 'wpmedia_plugin_family_show_imagify_banner', true ) ) {
+		if ( ! $this->should_show_imagify_banner() ) {
 			return;
 		}
 
@@ -483,14 +476,7 @@ class PluginFamily implements PluginFamilyInterface {
 			$can_enqueue = in_array( get_current_screen()->id, $allowed_screen_ids, true );
 		}
 
-		/**
-		 * Filters whether to show the Imagify banner on Media gallery components.
-		 *
-		 * @since 1.0.8
-		 *
-		 * @param bool $can_enqueue Whether to enqueue the admin assets and show the banner.
-		 */
-		return wpm_apply_filters_typed( 'boolean', 'wpmedia_plugin_family_show_imagify_banner', $can_enqueue );
+		return $this->should_show_imagify_banner( $can_enqueue );
 	}
 
 	/**
@@ -594,5 +580,26 @@ class PluginFamily implements PluginFamilyInterface {
 	 */
 	private function is_promote_imagify_dismissed() {
 		return ! empty( get_option( 'plugin_family_dismiss_promote_imagify' ) );
+	}
+
+	/**
+	 * Check if the Imagify banner should be shown.
+	 *
+	 * Applies the filter to allow developers to control banner visibility.
+	 *
+	 * @since 1.0.8
+	 *
+	 * @param bool $default_value The default value to filter.
+	 * @return bool Whether to show the Imagify banner.
+	 */
+	private function should_show_imagify_banner( bool $default_value = true ): bool {
+		/**
+		 * Filters whether to show the Imagify banner on Media gallery components.
+		 *
+		 * @since 1.0.8
+		 *
+		 * @param bool $show_banner Whether to show the Imagify banner.
+		 */
+		return wpm_apply_filters_typed( 'boolean', 'wpmedia_plugin_family_show_imagify_banner', $default_value );
 	}
 }

--- a/src/Controller/PluginFamily.php
+++ b/src/Controller/PluginFamily.php
@@ -387,7 +387,7 @@ class PluginFamily implements PluginFamilyInterface {
 		 *
 		 * @param bool $show_banner Whether to enqueue the block editor assets and show the banner.
 		 */
-		if ( ! wpm_apply_filters_typed( 'bool', 'wpmedia_plugin_family_show_imagify_banner', true ) ) {
+		if ( ! wpm_apply_filters_typed( 'boolean', 'wpmedia_plugin_family_show_imagify_banner', true ) ) {
 			return;
 		}
 

--- a/src/Controller/PluginFamily.php
+++ b/src/Controller/PluginFamily.php
@@ -380,6 +380,17 @@ class PluginFamily implements PluginFamilyInterface {
 			return;
 		}
 
+		/**
+		 * Filters whether to show the Imagify banner on Media gallery components.
+		 *
+		 * @since 1.0.7
+		 *
+		 * @param bool $show_banner Whether to enqueue the block editor assets and show the banner.
+		 */
+		if ( ! wpm_apply_filters_typed( 'bool', 'wpmedia_plugin_family_show_imagify_banner', true ) ) {
+			return;
+		}
+
 		$script_url = plugin_dir_url( __DIR__ ) . 'assets/js/index.js';
 
 		wp_enqueue_script(

--- a/src/Controller/PluginFamily.php
+++ b/src/Controller/PluginFamily.php
@@ -383,7 +383,7 @@ class PluginFamily implements PluginFamilyInterface {
 		/**
 		 * Filters whether to show the Imagify banner on Media gallery components.
 		 *
-		 * @since 1.0.7
+		 * @since 1.0.8
 		 *
 		 * @param bool $show_banner Whether to enqueue the block editor assets and show the banner.
 		 */
@@ -486,7 +486,7 @@ class PluginFamily implements PluginFamilyInterface {
 		/**
 		 * Filters whether to show the Imagify banner on Media gallery components.
 		 *
-		 * @since 1.0.7
+		 * @since 1.0.8
 		 *
 		 * @param bool $can_enqueue Whether to enqueue the admin assets and show the banner.
 		 */

--- a/src/Controller/PluginFamily.php
+++ b/src/Controller/PluginFamily.php
@@ -447,6 +447,8 @@ class PluginFamily implements PluginFamilyInterface {
 		}
 
 		$allowed_pages = $this->screen_ids;
+		$can_enqueue   = in_array( $page, $allowed_pages, true );
+
 		if ( empty( $page ) ) {
 			// Map configured admin pages to corresponding get_current_screen()->id values.
 			$allowed_screen_ids = array_unique(
@@ -468,8 +470,6 @@ class PluginFamily implements PluginFamilyInterface {
 			);
 
 			$can_enqueue = in_array( get_current_screen()->id, $allowed_screen_ids, true );
-		} else {
-			$can_enqueue = in_array( $page, $allowed_pages, true );
 		}
 
 		/**

--- a/src/Controller/PluginFamily.php
+++ b/src/Controller/PluginFamily.php
@@ -12,7 +12,7 @@ class PluginFamily implements PluginFamilyInterface {
 	 *
 	 * @var string
 	 */
-	private $version = '1.0.6';
+	private $version = '1.0.7';
 
 	/**
 	 * Error transient.
@@ -467,10 +467,19 @@ class PluginFamily implements PluginFamilyInterface {
 				)
 			);
 
-			return in_array( get_current_screen()->id, $allowed_screen_ids, true );
+			$can_enqueue = in_array( get_current_screen()->id, $allowed_screen_ids, true );
+		} else {
+			$can_enqueue = in_array( $page, $allowed_pages, true );
 		}
 
-		return in_array( $page, $allowed_pages, true );
+		/**
+		 * Filters whether to show the Imagify banner on Media gallery components.
+		 *
+		 * @since 1.0.7
+		 *
+		 * @param bool $can_enqueue Whether to enqueue the admin assets and show the banner.
+		 */
+		return wpm_apply_filters_typed( 'bool', 'wpmedia_plugin_family_show_imagify_banner', $can_enqueue );
 	}
 
 	/**


### PR DESCRIPTION
# Description

Fixes wp-media/wp-rocket#7556

Add filter to control Imagify banner on Media gallery components
- Add 'wpmedia_plugin_family_show_imagify_banner' filter to allow developers to control banner visibility
- Banner is enabled by default and can be disabled by setting filter to false
- Bump version to 1.0.7

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

### How to test

1. Install WP Rocket
2. Ensure Imagify is not installed or activated
3. Navigate to Media > Library or edit a post
4. Verify the Imagify promotion banner appears or not

### How to test

Use the filter `add_filter( 'wpmedia_plugin_family_show_imagify_banner', '__return_false' );` to enable/disable the banner

### Affected Features & Quality Assurance Scope

- **Imagify promotion banner**: The banner display logic now includes a filter hook, allowing third-party customization
- **Media library and post editor screens**: These are the primary screens where the banner appears
- **Default behavior**: No changes to existing functionality - banner still shows by default

## Technical description

### Documentation

This pull request introduces a new dependency for typed filter application, updates the plugin version, and enhances the logic for displaying the Imagify banner by making it filterable and type-safe. The most important changes are grouped below:

Dependency management:

* Added a new required dependency on `wp-media/apply-filters-typed` in `composer.json` to support type-safe filter application.

Plugin versioning:

* Updated the plugin version from `1.0.6` to `1.0.7` in `PluginFamily.php`.

Admin banner display logic:

* Refactored the logic for determining when to show the Imagify banner in the admin area, and introduced a new filter `wpmedia_plugin_family_show_imagify_banner` that uses the new type-safe filter application (`wpm_apply_filters_typed`). This allows developers to reliably modify the banner display behavior.
### New dependencies

`"wp-media/apply-filters-typed": "^1.0"` in `composer.json`
### Risks

None

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.
