### PR TITLE
Update WPR referral link when using Imagify

### DIFF
--- a/src/Model/PluginFamily.php
+++ b/src/Model/PluginFamily.php
@@ -120,7 +120,7 @@ class PluginFamily {
 					];
 
 					if ( 'imagify' === $wpr_referrer ) {
-						$url  = 'https://wp-rocket.me/wp-rocket-for-imagify-users/';
+						$url      = 'https://wp-rocket.me/wp-rocket-for-imagify-users/';
 						$wpr_args = [
 							'utm_source'   => 'imagify',
 							'utm_medium'   => 'partners',

--- a/src/Model/PluginFamily.php
+++ b/src/Model/PluginFamily.php
@@ -112,7 +112,23 @@ class PluginFamily {
 
 				// Create unique CTA data for WP Rocket.
 				if ( 'wp-rocket/wp-rocket' === $plugin ) {
-					$url = 'https://wp-rocket.me/?utm_source=' . $wpr_referrer . '-coupon&utm_medium=plugin&utm_campaign=' . $wpr_referrer;
+					$url  = 'https://wp-rocket.me/';
+					$args = [
+						'utm_source'   => $wpr_referrer . '-coupon',
+						'utm_medium'   => 'plugin',
+						'utm_campaign' => $wpr_referrer,
+					];
+
+					if ( 'imagify' === $wpr_referrer ) {
+						$url  = 'https://wp-rocket.me/wp-rocket-for-imagify-users/';
+						$args = [
+							'utm_source'   => 'imagify',
+							'utm_medium'   => 'partners',
+							'utm_campaign' => 'imagify-benefits',
+						];
+					}
+
+					$url = add_query_arg( $args, $url );
 
 					$plugins[ $cat ]['plugins'][ $plugin ]['cta'] = [
 						'text' => __( 'Get it Now', '%domain%' ),

--- a/src/Model/PluginFamily.php
+++ b/src/Model/PluginFamily.php
@@ -112,8 +112,8 @@ class PluginFamily {
 
 				// Create unique CTA data for WP Rocket.
 				if ( 'wp-rocket/wp-rocket' === $plugin ) {
-					$url  = 'https://wp-rocket.me/';
-					$args = [
+					$url      = 'https://wp-rocket.me/';
+					$wpr_args = [
 						'utm_source'   => $wpr_referrer . '-coupon',
 						'utm_medium'   => 'plugin',
 						'utm_campaign' => $wpr_referrer,
@@ -121,14 +121,14 @@ class PluginFamily {
 
 					if ( 'imagify' === $wpr_referrer ) {
 						$url  = 'https://wp-rocket.me/wp-rocket-for-imagify-users/';
-						$args = [
+						$wpr_args = [
 							'utm_source'   => 'imagify',
 							'utm_medium'   => 'partners',
 							'utm_campaign' => 'imagify-benefits',
 						];
 					}
 
-					$url = add_query_arg( $args, $url );
+					$url = add_query_arg( $wpr_args, $url );
 
 					$plugins[ $cat ]['plugins'][ $plugin ]['cta'] = [
 						'text' => __( 'Get it Now', '%domain%' ),

--- a/tests/Fixtures/src/Model/PluginFamily/filterPluginsByActivation.php
+++ b/tests/Fixtures/src/Model/PluginFamily/filterPluginsByActivation.php
@@ -141,10 +141,10 @@ $expectedCategoryWithActivePluginAsTheLastElement = [
         ],
         'title' => 'Speed Up Your Website, Instantly',
         'desc'  => 'WP Rocket is the easiest way to make your WordPress website faster and boost your Google PageSpeed score. Get more traffic, better engagement, and higher conversions effortlessly.',
-        'link'  => 'https://wp-rocket.me/?utm_source=imagify-coupon&utm_medium=plugin&utm_campaign=imagify',
+        'link'  => 'https://wp-rocket.me/wp-rocket-for-imagify-users/?utm_source=imagify&utm_medium=partners&utm_campaign=imagify-benefits',
         'cta'   => [
             'text' => 'Get it Now',
-            'url'  => 'https://wp-rocket.me/?utm_source=imagify-coupon&utm_medium=plugin&utm_campaign=imagify'
+            'url'  => 'https://wp-rocket.me/wp-rocket-for-imagify-users/?utm_source=imagify&utm_medium=partners&utm_campaign=imagify-benefits'
         ],
     ],
     'backwpup/backwpup'                   => [


### PR DESCRIPTION
# Description

Update the WPR referral link when using Imagify to redirect to the appropriate landing page, and associate the correct UTM parameters.

Related https://github.com/wp-media/imagify-plugin/issues/1008

## Type of change

- [x] Enhancement (non-breaking change which improves an existing functionality).

## Detailed scenario

### What was tested

While on Imagify settings page with WP Rocket uninstalled and checked the link to WP Rocket is the correct one updated

### How to test

- Use this branch on imagify by using `dev-enhancement/rocket-url` as the version for the plugin-family package in composer
- run `composer update`
- Go to imagify Imagify settings page with WP Rocket uninstalled
- Check the link to WP Rocket

### Affected Features & Quality Assurance Scope

Plugin family display on Imagify settings page

## Technical description

### Documentation

Updates the WP Rocket referral destination and UTM tracking when the plugin family UI is being shown from Imagify, ensuring the CTA/link points to the correct landing page for Imagify users.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [x] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [x] I implemented built-in tests to cover the new/changed code.

## Code style

- [x] I wrote a self-explanatory code about what it does.
- [x] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [x] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.