### PR TITLE
Fixes #32 Remove files from export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,5 @@ README.md export-ignore
 phpstan-stubs export-ignore
 src/assets/js/index.assets.php export-ignore
 assets-src export-ignore
+webpack.config.js export-ignore
+package-lock.json export-ignore


### PR DESCRIPTION
# Description

Fixes #32

Remove `package-lock.json` and `webpack.config.js` from production files

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Detailed scenario

### What was tested

Files are not present anymore when exporting the library (through composer for example)

### How to test

Use branch `dev-fix/32-package-lock` as version for the plugin family in composer file. Check the files are not present in the folder

### Affected Features & Quality Assurance Scope

No feature affected directly

## Technical description

### Documentation


This PR updates the project’s export configuration so that development/build artifacts are excluded from distribution archives (e.g., Composer/GitHub “dist” installs), aligning with issue #32’s goal of reducing security scanner noise from non-production files.

# Mandatory Checklist

## Code validation

- [x] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [ ] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [x] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

Not applicable for this PR